### PR TITLE
Fix download with file_offset and download_bytes

### DIFF
--- a/fdfs_client/client.py
+++ b/fdfs_client/client.py
@@ -364,10 +364,8 @@ class Fdfs_client(object):
         if not tmp:
             raise DataError('[-] Error: remote_file_id is invalid.(in download file)')
         group_name, remote_filename = tmp
-        if not offset:
-            file_offset = long(offset)
-        if not down_bytes:
-            download_bytes = long(down_bytes)
+        file_offset = long(offset)
+        download_bytes = long(down_bytes)
         tc = Tracker_client(self.tracker_pool)
         store_serv = tc.tracker_query_storage_fetch(group_name, remote_filename)
         store = Storage_client(store_serv.ip_addr, store_serv.port, self.timeout)
@@ -393,10 +391,8 @@ class Fdfs_client(object):
         if not tmp:
             raise DataError('[-] Error: remote_file_id is invalid.(in download file)')
         group_name, remote_filename = tmp
-        if not offset:
-            file_offset = long(offset)
-        if not down_bytes:
-            download_bytes = long(down_bytes)
+        file_offset = long(offset)
+        download_bytes = long(down_bytes)
         tc = Tracker_client(self.tracker_pool)
         store_serv = tc.tracker_query_storage_fetch(group_name, remote_filename)
         store = Storage_client(store_serv.ip_addr, store_serv.port, self.timeout)


### PR DESCRIPTION
``` python
from fdfs_client.client import *
client = Fdfs_client("client.conf")
ret = client.download_to_buffer(afid, 3, 5)
print ret
```

Traceback (most recent call last):
  File "atest.py", line 16, in <module>
    ret = client.download_to_buffer("tpupfs1/M00/00/00/CtwCr1WscGmAVmNjAAAAC5npnuQ0602068", 3, 5)
  File "/Volumes/Hmwork/myfdfs/fdfs_client/client.py", line 405, in download_to_buffer
    file_offset, download_bytes, \
UnboundLocalError: local variable 'file_offset' referenced before assignment
